### PR TITLE
- 修复：dist path

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -42,7 +42,7 @@ export default {
             preamble: fs.readFileSync('./src/scripts/header.js').toString()
               .replace(/__VERSION__/g, VERSION)
               .replace(/__NAME__/g, NAME)
-              .replace(/__UPDATE_URL__/g, `https://github.com/HCLonely/auto-task/main/dist/${NAME}.user.js`)
+              .replace(/__UPDATE_URL__/g, `https://github.com/HCLonely/auto-task/raw/main/dist/${NAME}.user.js`)
               .replace(/__CHECK_DEPENDENCIES__/g, fs.readFileSync('./src/scripts/checkDependence.js').toString())
               .replace(/__ALL_URL__/g, `https://github.com/HCLonely/auto-task/raw/main/dist/${NAME}.all.user.js`)
           },


### PR DESCRIPTION
- [x] 修复BUG<!-- Fix bug -->

Most of the .user.js files point to wrong download URLs, so the project cannot update ever again. I think this rollup config might be the right place to address it?

The problem looks like this:
page/dist/auto-task.user.js
```
12:// @updateURL          https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
13:// @installURL         https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
14:// @downloadURL        https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
```

page/dist/auto-task.all.user.js
```
12:// @updateURL          https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
13:// @installURL         https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
14:// @downloadURL        https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
```

dist/auto-task.user.js
```
12:// @updateURL          https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
13:// @installURL         https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
14:// @downloadURL        https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
```

dist/auto-task.all.user.js
```
12:// @updateURL          https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
13:// @installURL         https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
14:// @downloadURL        https://github.com/HCLonely/auto-task/main/dist/auto-task.user.js
```